### PR TITLE
Custom fields

### DIFF
--- a/includes/document-post-type.php
+++ b/includes/document-post-type.php
@@ -218,7 +218,7 @@ class Document {
 					)
 				)
 			),
-			'position' => 'normal',
+			'position' => 'acf_after_title',
 			'style'    => 'default',
 			'active'   => true
 		);

--- a/includes/document-post-type.php
+++ b/includes/document-post-type.php
@@ -208,6 +208,8 @@ class Document {
 			'instructions' => 'A short description that will be displayed with the file.'
 		);
 
+		$fields = apply_filters( 'ucf_document_fields', $fields );
+
 		$field_group = array(
 			'key'      => 'ucf_document_fields',
 			'title'    => 'Document Fields',

--- a/includes/document-post-type.php
+++ b/includes/document-post-type.php
@@ -5,6 +5,8 @@
  */
 namespace UCFDocument\PostTypes;
 
+use UCFDocument\Utils;
+
 class Document {
 	private
 		$singular,
@@ -18,6 +20,10 @@ class Document {
 	 */
 	public function __construct() {
 		add_action( 'init', array( $this, 'register' ), 10, 0 );
+
+		if ( Utils\acf_is_active() ) {
+			add_action( 'acf/init', array( $this, 'fields' ), 10, 0 );
+		}
 	}
 
 	/**
@@ -125,6 +131,99 @@ class Document {
 		$args = apply_filters( 'ucf_document_args', $args );
 
 		return $args;
+	}
+
+	/**
+	 * Adds custom fields for the document
+	 * custom post type
+	 * @author Jim Barnes
+	 * @since 0.1.0
+	 * @return void
+	 */
+	public function fields() {
+		// Bail out if the function doesn't exists, for whatever reason.
+		if ( ! function_exists( 'acf_add_local_field_group' ) ) return;
+
+		$fields  = array();
+
+		$fields[] = array(
+			'key'      => 'document_type',
+			'label'    => 'Type',
+			'name'     => 'document_type',
+			'type'     => 'radio',
+			'choices'  => array(
+				'uploaded' => 'Uploaded',
+				'external' => 'External'
+			),
+			'default_choice' => array(
+				'uploaded' => 'Uploaded'
+			),
+			'required' => 1
+		);
+
+		$fields[] = array(
+			'key'               => 'document_upload',
+			'label'             => 'Uploaded File',
+			'name'              => 'document_upload',
+			'type'              => 'file',
+			'instructions'      => 'Upload the document',
+			'required'          => 0,
+			'conditional_logic' => array(
+				array(
+					array(
+						'key'      => 'document_type',
+						'operator' => '==',
+						'value'    => 'uploaded'
+					)
+				)
+			)
+		);
+
+		$fields[] = array(
+			'key'      => 'document_external',
+			'label'    => 'External File',
+			'name'     => 'document_external',
+			'type'     => 'text',
+			'required' => 0,
+			'conditional_logic' => array(
+				array(
+					array(
+						'key'      => 'document_type',
+						'operator' => '==',
+						'value'    => 'external'
+					)
+				)
+			)
+		);
+
+		$fields[] = array(
+			'key'          => 'document_description',
+			'label'        => 'Short Description',
+			'name'         => 'document_description',
+			'type'         => 'textarea',
+			'required'     => 0,
+			'instructions' => 'A short description that will be displayed with the file.'
+		);
+
+		$field_group = array(
+			'key'      => 'ucf_document_fields',
+			'title'    => 'Document Fields',
+			'fields'   => $fields,
+			'location' => array(
+				array(
+					array(
+						'param'    => 'post_type',
+						'operator' => '==',
+						'value'    => 'document'
+					)
+				)
+			),
+			'position' => 'normal',
+			'style'    => 'default',
+			'active'   => true
+		);
+
+		acf_add_local_field_group( $field_group );
 	}
 }
 

--- a/includes/document-post-type.php
+++ b/includes/document-post-type.php
@@ -21,6 +21,7 @@ class Document {
 	public function __construct() {
 		add_action( 'init', array( $this, 'register' ), 10, 0 );
 		add_action( 'posts_results', array( $this, 'meta' ), 10, 2 );
+		add_filter( 'single_template', array( $this, 'single_template' ), 10, 1 );
 
 		if ( Utils\acf_is_active() ) {
 			add_action( 'acf/init', array( $this, 'fields' ), 10, 0 );
@@ -169,7 +170,7 @@ class Document {
 			'type'              => 'file',
 			'instructions'      => 'Upload the document',
 			'required'          => 0,
-			'save_format'       => 'url',
+			'save_format'       => 'object',
 			'conditional_logic' => array(
 				array(
 					array(
@@ -273,6 +274,18 @@ class Document {
 		$post->meta = (object)$meta;
 
 		return $post;
+	}
+
+	public function single_template( $single ) {
+		global $post;
+
+		if ( $post->post_type === 'document' ) {
+			if ( file_exists( UCF_DOCUMENT__PLUGIN_PATH . '/templates/single-document.php' ) ) {
+				return UCF_DOCUMENT__PLUGIN_PATH . '/templates/single-document.php';
+			}
+		}
+
+		return $single;
 	}
 }
 

--- a/templates/single-document.php
+++ b/templates/single-document.php
@@ -4,23 +4,25 @@
  */
 the_post();
 if ( $post->meta->type === 'uploaded' ) {
-	$filepath = $post->meta->file['link'];
-	$filename = $post->meta->file['filename'];
-	$filemime = $post->meta->file['mime_type'];
-	$filesize = $post->meta->file['filesize'];
+	if ( isset( $post->meta->file['link'] ) ) {
+		$filepath = $post->meta->file['link'];
+		$filename = $post->meta->file['filename'];
+		$filemime = $post->meta->file['mime_type'];
+		$filesize = $post->meta->file['filesize'];
 
-	header($_SERVER["SERVER_PROTOCOL"] . " 200 OK");
-	header("Expires: 0");
-	header("Cache-Control: no-cache, no-store, must-revalidate");
-	header('Cache-Control: pre-check=0, post-check=0, max-age=0', false);
-	header("Pragma: no-cache");
-	header("Cache-Control: public");
-	header("Content-Type: " . $filemime );
-	header("Content-Transfer-Encoding: Binary");
-	header("Content-Length:" . $filesize );
-	header("Content-Disposition: attachment; filename=" . $filename);
-	readfile( $filepath );
-	return;
+		header($_SERVER["SERVER_PROTOCOL"] . " 200 OK");
+		header("Expires: 0");
+		header("Cache-Control: no-cache, no-store, must-revalidate");
+		header('Cache-Control: pre-check=0, post-check=0, max-age=0', false);
+		header("Pragma: no-cache");
+		header("Cache-Control: public");
+		header("Content-Type: " . $filemime );
+		header("Content-Transfer-Encoding: Binary");
+		header("Content-Length:" . $filesize );
+		header("Content-Disposition: attachment; filename=" . $filename);
+		readfile( $filepath );
+		return;
+	}
 } else if ( ! empty( $post->meta->file ) ) {
 	header("Expires: 0");
 	header("Cache-Control: no-cache, no-store, must-revalidate");

--- a/templates/single-document.php
+++ b/templates/single-document.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * The Single Document template
+ */
+the_post();
+if ( $post->meta->type === 'uploaded' ) {
+	$filepath = $post->meta->file['link'];
+	$filename = $post->meta->file['filename'];
+	$filemime = $post->meta->file['mime_type'];
+	$filesize = $post->meta->file['filesize'];
+
+	header($_SERVER["SERVER_PROTOCOL"] . " 200 OK");
+	header("Cache-Control: public");
+	header("Content-Type: " . $filemime );
+	header("Content-Transfer-Encoding: Binary");
+	header("Content-Length:" . $filesize );
+	header("Content-Disposition: attachment; filename=" . $filename);
+	readfile( $filepath );
+	return;
+} else {
+	if ( ! empty( $post->meta->file ) ) {
+		wp_redirect( $post->meta->file, 301 );
+		exit;
+	}
+
+	exit;
+}
+
+exit;

--- a/templates/single-document.php
+++ b/templates/single-document.php
@@ -10,6 +10,10 @@ if ( $post->meta->type === 'uploaded' ) {
 	$filesize = $post->meta->file['filesize'];
 
 	header($_SERVER["SERVER_PROTOCOL"] . " 200 OK");
+	header("Expires: 0");
+	header("Cache-Control: no-cache, no-store, must-revalidate");
+	header('Cache-Control: pre-check=0, post-check=0, max-age=0', false);
+	header("Pragma: no-cache");
 	header("Cache-Control: public");
 	header("Content-Type: " . $filemime );
 	header("Content-Transfer-Encoding: Binary");
@@ -17,11 +21,13 @@ if ( $post->meta->type === 'uploaded' ) {
 	header("Content-Disposition: attachment; filename=" . $filename);
 	readfile( $filepath );
 	return;
-} else {
-	if ( ! empty( $post->meta->file ) ) {
-		wp_redirect( $post->meta->file, 301 );
-		exit;
-	}
+} else if ( ! empty( $post->meta->file ) ) {
+	header("Expires: 0");
+	header("Cache-Control: no-cache, no-store, must-revalidate");
+	header('Cache-Control: pre-check=0, post-check=0, max-age=0', false);
+	header("Pragma: no-cache");
+	wp_redirect( $post->meta->file, 301 );
+	exit;
 }
 
 // If you've made it down here, you're in dangerous territory

--- a/templates/single-document.php
+++ b/templates/single-document.php
@@ -22,8 +22,13 @@ if ( $post->meta->type === 'uploaded' ) {
 		wp_redirect( $post->meta->file, 301 );
 		exit;
 	}
-
-	exit;
 }
 
+// If you've made it down here, you're in dangerous territory
+global $wp_query;
+$wp_query->set_404();
+status_header(404);
+$template = get_404_template();
+
+include_once $template;
 exit;

--- a/ucf-document.php
+++ b/ucf-document.php
@@ -24,9 +24,9 @@ define( 'UCF_DOCUMENT__PLUGIN_PATH', dirname( __FILE__ ) );
 /**
  * Includes
  */
+require_once 'includes/utilities.php';
 require_once 'includes/document-post-type.php';
 require_once 'includes/directory-taxonomy.php';
-require_once 'includes/utilities.php';
 
 /**
  * Activation/Deactivation Hooks


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Document-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Document-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Provides the custom fields for the document custom post type. Also, includes the logic for how the post type is returned and displayed by WordPress by default.

**Motivation and Context**
The core of the plugin is in this pull request. The document type field controls whether a file or text field is presented to the user (for uploaded and external files, respectively), and the short description provides a text area for describing the file.

In addition, default logic for adding the file `meta` to posts when they're queried has been added, to simplify the logic needed to determine where to send a user.

A default template has been defined which either downloads the file, redirects the user or 404s depending on the situation. 

**How Has This Been Tested?**
Changes are available for review in dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
