### PR TITLE
ACF plugin exist

### DIFF
--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -18,14 +18,14 @@ function acf_is_active( $required_version = '5.0.0' ) {
 	$plugin_path   = ABSPATH . 'wp-content/plugins/';
 
 	// See if the pro version is installed
-	if ( is_plugin_active( $acf_pro_path ) ) {
+	if ( class_exists( 'acf_pro' ) ) {
 		$plugin_data = get_plugin_data( $plugin_path . $acf_pro_path );
 
 		if ( is_above_version( $plugin_data['Version'], $required_version ) ) {
 			return true;
 		}
 	}
-	if ( is_plugin_active( $acf_free_path ) ) {
+	if ( class_exists( 'ACF' ) ) {
 		$plugin_data = get_plugin_data( $plugin_path . $acf_free_path );
 
 		if ( is_above_version( $plugin_data['Version'], $required_version ) ) {


### PR DESCRIPTION

<!---
Thank you for contributing to UCF-Document-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Document-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
is_plugin_active() is no longer working in wordpress 5.5.1, Using class_exisit to check if a class in a plugin exist. 

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I received an error on line 21 of utilities when trying to activate the plugin

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Locally

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

switch is_plugin_active to class_exisit

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
