### PR TITLE
Escaped some non-namespaced function calls

### DIFF
--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -13,20 +13,20 @@ namespace UCFDocument\Utils;
  * @param string $required_version The version the plugin must be
  */
 function acf_is_active( $required_version = '5.0.0' ) {
-	$acf_pro_path  = apply_filters( 'ucf_document_acf_pro_path', 'advanced-custom-fields-pro/acf.php' );
-	$acf_free_path = apply_filters( 'ucf_document_acf_free_path', 'advanced-custom-fields/acf.php' );
+	$acf_pro_path  = \apply_filters( 'ucf_document_acf_pro_path', 'advanced-custom-fields-pro/acf.php' );
+	$acf_free_path = \apply_filters( 'ucf_document_acf_free_path', 'advanced-custom-fields/acf.php' );
 	$plugin_path   = ABSPATH . 'wp-content/plugins/';
 
 	// See if the pro version is installed
-	if ( class_exists( 'acf_pro' ) || safe_is_plugin_active( $acf_pro_path ) ) {
-		$plugin_data = get_plugin_data( $plugin_path . $acf_pro_path );
+	if ( \class_exists( 'acf_pro' ) || safe_is_plugin_active( $acf_pro_path ) ) {
+		$plugin_data = \get_plugin_data( $plugin_path . $acf_pro_path );
 
 		if ( is_above_version( $plugin_data['Version'], $required_version ) ) {
 			return true;
 		}
 	}
-	if ( class_exists( 'ACF' ) || safe_is_plugin_active( $acf_free_path ) ) {
-		$plugin_data = get_plugin_data( $plugin_path . $acf_free_path );
+	if ( \class_exists( 'ACF' ) || safe_is_plugin_active( $acf_free_path ) ) {
+		$plugin_data = \get_plugin_data( $plugin_path . $acf_free_path );
 
 		if ( is_above_version( $plugin_data['Version'], $required_version ) ) {
 			return true;


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Document-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Document-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.  There's a bizarre bug happening in one of our production instances where PHP seems to think that `get_plugin_data()`, a vanilla WP function, is supposed to be namespaced under `UCFDocument\Utils`, but isn't, and throws a fatal error:

```
PHP Fatal error:  Uncaught Error: Call to undefined function UCFDocument\Utils\get_plugin_data() in UCF-Document-Plugin/includes/utilities.php:22
Stack trace:
#0 UCF-Document-Plugin/includes/document-post-type.php(27): UCFDocument\Utils\acf_is_active()
```

https://github.com/UCF/UCF-Document-Plugin/blob/4ebbb5c14c3fee0e1f70b14fc4a45a8a9e96cd50/includes/utilities.php#L1-L37

Why this error doesn't happen on lines 16 or 17, where `apply_filters()` is called, I don't know.  I'm mostly putting this PR together as a stopgap until we can figure out why this particular production env is acting strangely.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Pretty much explained above

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Unfortunately we can't really verify this works until it's pushed up to the particular production instance that's having issues.  I've confirmed nothing in QA breaks with this update at least.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
