### PR TITLE
Added check to make sure the get_plugin_data function is available

### DIFF
--- a/includes/utilities.php
+++ b/includes/utilities.php
@@ -17,6 +17,10 @@ function acf_is_active( $required_version = '5.0.0' ) {
 	$acf_free_path = \apply_filters( 'ucf_document_acf_free_path', 'advanced-custom-fields/acf.php' );
 	$plugin_path   = ABSPATH . 'wp-content/plugins/';
 
+	if ( ! function_exists( 'get_plugin_data' ) ) {
+		require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
+	}
+
 	// See if the pro version is installed
 	if ( \class_exists( 'acf_pro' ) || safe_is_plugin_active( $acf_pro_path ) ) {
 		$plugin_data = \get_plugin_data( $plugin_path . $acf_pro_path );


### PR DESCRIPTION
<!---
Thank you for contributing to UCF-Document-Plugin.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/UCF-Document-Plugin/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Ensures the `plugin.php` file is included before trying to use the `get_plugin_data` function that is found in it.

**Motivation and Context**
During certain actions, specifically wp-cli commands, the `plugin.php` may not be included when the `get_plugin_data` gets called, raising an exception because the function is not yet defined. This adds an additional check and includes the file if the function isn't defined.

**How Has This Been Tested?**
Changes have been tested locally.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
